### PR TITLE
Remove unused capability fields from config flow

### DIFF
--- a/custom_components/drp_climate_master_v2/config_flow.py
+++ b/custom_components/drp_climate_master_v2/config_flow.py
@@ -56,18 +56,12 @@ from .helpers.config_flow import (
     validate_devices,
     validate_scenarios,
     validate_historical_data,
-    validate_min_max,
     validate_apt_windows,
     validate_confort_zones,
 )
 from .helpers.config_flow_entries_payload import yaml_climate_to_entry_payload
 
 from .helpers.config_flow_ui_schemas import (
-    OPT_MANUAL_OVERRIDE_MIN,
-    OPT_SETPOINT_STEP_C,
-    OPT_SUPPORTS_COOLING,
-    OPT_SUPPORTS_DEHUMIDIFYING,
-    OPT_SUPPORTS_HEATING,
     OPT_UPDATE_INTERVAL_S,
     schema_user,
     schema_dynamic,
@@ -79,15 +73,6 @@ from .helpers.config_flow_ui_schemas import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-# Opzioni runtime (allineate al runtime_config)
-# OPT_UPDATE_INTERVAL_S = "update_interval_s"
-# OPT_SUPPORTS_HEATING = "supports_heating"
-# OPT_SUPPORTS_COOLING = "supports_cooling"
-# OPT_SUPPORTS_DEHUMIDIFYING = "supports_dehumidifying"
-# OPT_SETPOINT_STEP_C = "setpoint_step_c"
-# OPT_MANUAL_OVERRIDE_MIN = "manual_override_minutes"
-
 
 class DrpClimateMasterConfigFlow(ConfigFlow, domain=DOMAIN):
     """Config Flow: orchestrazione UI e gestione import."""
@@ -140,16 +125,8 @@ class DrpClimateMasterConfigFlow(ConfigFlow, domain=DOMAIN):
             CONF_APT_WINDOWS: {CONF_STATE: str(apt_windows_state)},
             CONF_CONFORT_ZONES: {},
             CONF_UNITS: str(DEFAULT_UNITS),
-            CONF_MAX_TEMP: 35.0,
-            CONF_MIN_TEMP: 5.0,
-            CONF_STEP: 0.5,
             CONF_TEMPERATURE_UNIT: str(DEFAULT_TEMP_UNIT),
             OPT_UPDATE_INTERVAL_S: 30,
-            OPT_SUPPORTS_HEATING: True,
-            OPT_SUPPORTS_COOLING: False,
-            OPT_SUPPORTS_DEHUMIDIFYING: False,
-            OPT_SETPOINT_STEP_C: 0.5,
-            OPT_MANUAL_OVERRIDE_MIN: 90,
         }
 
         return await self.async_step_dynamic()
@@ -162,26 +139,10 @@ class DrpClimateMasterConfigFlow(ConfigFlow, domain=DOMAIN):
                 data_schema=schema_dynamic(self._entry_options, self._entry_data),
             )
 
-        err = validate_min_max(user_input[CONF_MIN_TEMP], user_input[CONF_MAX_TEMP])
-        if err:
-            return self.async_show_form(
-                step_id="dynamic",
-                data_schema=schema_dynamic(self._entry_options, self._entry_data),
-                errors={"base": err},
-            )
-
         new_options: Dict[str, Any] = dict(self._entry_options)
         new_options.update(
             {
                 OPT_UPDATE_INTERVAL_S: user_input[OPT_UPDATE_INTERVAL_S],
-                OPT_SUPPORTS_HEATING: user_input[OPT_SUPPORTS_HEATING],
-                OPT_SUPPORTS_COOLING: user_input[OPT_SUPPORTS_COOLING],
-                OPT_SUPPORTS_DEHUMIDIFYING: user_input[OPT_SUPPORTS_DEHUMIDIFYING],
-                OPT_SETPOINT_STEP_C: float(user_input[OPT_SETPOINT_STEP_C]),
-                OPT_MANUAL_OVERRIDE_MIN: user_input[OPT_MANUAL_OVERRIDE_MIN],
-                CONF_MAX_TEMP: float(user_input[CONF_MAX_TEMP]),
-                CONF_MIN_TEMP: float(user_input[CONF_MIN_TEMP]),
-                CONF_STEP: float(user_input[CONF_STEP]),
                 CONF_UNITS: str(user_input[CONF_UNITS]),
                 CONF_TEMPERATURE_UNIT: str(user_input[CONF_TEMPERATURE_UNIT]),
             }
@@ -501,22 +462,21 @@ class DrpClimateMasterOptionsFlowHandler(OptionsFlow):
         if user_input is None:
             return self.async_show_form(step_id="dynamic", data_schema=schema_dynamic(cur, self.entry.data))
 
-        err = validate_min_max(user_input[CONF_MIN_TEMP], user_input[CONF_MAX_TEMP])
-        if err:
-            return self.async_show_form(step_id="dynamic", data_schema=schema_dynamic(cur, self.entry.data), errors={"base": err})
-
         new_options: Dict[str, Any] = dict(cur)
+        for deprecated in (
+            CONF_MAX_TEMP,
+            CONF_MIN_TEMP,
+            CONF_STEP,
+            "setpoint_step_c",
+            "manual_override_minutes",
+            "supports_heating",
+            "supports_cooling",
+            "supports_dehumidifying",
+        ):
+            new_options.pop(deprecated, None)
         new_options.update(
             {
                 OPT_UPDATE_INTERVAL_S: user_input[OPT_UPDATE_INTERVAL_S],
-                OPT_SUPPORTS_HEATING: user_input[OPT_SUPPORTS_HEATING],
-                OPT_SUPPORTS_COOLING: user_input[OPT_SUPPORTS_COOLING],
-                OPT_SUPPORTS_DEHUMIDIFYING: user_input[OPT_SUPPORTS_DEHUMIDIFYING],
-                OPT_SETPOINT_STEP_C: float(user_input[OPT_SETPOINT_STEP_C]),
-                OPT_MANUAL_OVERRIDE_MIN: user_input[OPT_MANUAL_OVERRIDE_MIN],
-                CONF_MAX_TEMP: float(user_input[CONF_MAX_TEMP]),
-                CONF_MIN_TEMP: float(user_input[CONF_MIN_TEMP]),
-                CONF_STEP: float(user_input[CONF_STEP]),
                 CONF_UNITS: str(user_input[CONF_UNITS]),
                 CONF_TEMPERATURE_UNIT: str(user_input[CONF_TEMPERATURE_UNIT]),
             }

--- a/custom_components/drp_climate_master_v2/helpers/config_flow_entries_payload.py
+++ b/custom_components/drp_climate_master_v2/helpers/config_flow_entries_payload.py
@@ -20,9 +20,6 @@ from ..const import (
     CONF_HISTORICAL_DATA,
     CONF_WEATHER,
     CONF_UNITS,
-    CONF_MAX_TEMP,
-    CONF_MIN_TEMP,
-    CONF_STEP,
     DEFAULT_TEMP_UNIT,
     DEFAULT_UNITS,
     CONF_APT_WINDOWS,
@@ -37,18 +34,12 @@ from .config_flow import (
     validate_devices,
     validate_scenarios,
     validate_historical_data,
-    validate_min_max,
     validate_apt_windows,
     validate_confort_zones,
 )
 
 # Opzioni runtime (allineate al runtime_config)
 OPT_UPDATE_INTERVAL_S = "update_interval_s"
-OPT_SUPPORTS_HEATING = "supports_heating"
-OPT_SUPPORTS_COOLING = "supports_cooling"
-OPT_SUPPORTS_DEHUMIDIFYING = "supports_dehumidifying"
-OPT_SETPOINT_STEP_C = "setpoint_step_c"
-OPT_MANUAL_OVERRIDE_MIN = "manual_override_minutes"
 
 def yaml_climate_to_entry_payload(hub_name: str, climate: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """
@@ -73,9 +64,6 @@ def yaml_climate_to_entry_payload(hub_name: str, climate: Dict[str, Any]) -> Tup
     confort_zones = normalized_climate.get(CONF_CONFORT_ZONES, {})
 
     # Parametri climatici (con default come nello schema)
-    max_temp = normalized_climate.get(CONF_MAX_TEMP, 35.0)
-    min_temp = normalized_climate.get(CONF_MIN_TEMP, 5.0)
-    step = normalized_climate.get(CONF_STEP, 0.5)
     temp_unit = normalized_climate.get(CONF_TEMPERATURE_UNIT, DEFAULT_TEMP_UNIT)
     units = normalized_climate.get(CONF_UNITS, DEFAULT_UNITS)
 
@@ -108,10 +96,6 @@ def yaml_climate_to_entry_payload(hub_name: str, climate: Dict[str, Any]) -> Tup
     if not isinstance(apt_windows.get(CONF_STATE), str) or not apt_windows.get(CONF_STATE):
         raise ValueError("Manca 'apt_windows.state' (obbligatorio).")
 
-    err = validate_min_max(min_temp, max_temp)
-    if err:
-        raise ValueError(err)
-
     # Valida lo shape di weather e normalizza lat/lon
     weather_error, normalized_weather = normalize_weather_block(weather)
     if weather_error:
@@ -135,15 +119,7 @@ def yaml_climate_to_entry_payload(hub_name: str, climate: Dict[str, Any]) -> Tup
         CONF_CONFORT_ZONES: deepcopy(confort_zones),
         # runtime defaults
         OPT_UPDATE_INTERVAL_S: 30,
-        OPT_SUPPORTS_HEATING: True,
-        OPT_SUPPORTS_COOLING: False,
-        OPT_SUPPORTS_DEHUMIDIFYING: False,
-        OPT_SETPOINT_STEP_C: 0.5,
-        OPT_MANUAL_OVERRIDE_MIN: 90,
         # parametri climatici
-        CONF_MAX_TEMP: float(max_temp),
-        CONF_MIN_TEMP: float(min_temp),
-        CONF_STEP: float(step),
         CONF_TEMPERATURE_UNIT: str(temp_unit),
         CONF_UNITS: str(units),
     }

--- a/custom_components/drp_climate_master_v2/helpers/config_flow_ui_schemas.py
+++ b/custom_components/drp_climate_master_v2/helpers/config_flow_ui_schemas.py
@@ -16,9 +16,6 @@ from ..const import (
     CONF_HISTORICAL_DATA,
     CONF_WEATHER,
     CONF_UNITS,
-    CONF_MAX_TEMP,
-    CONF_MIN_TEMP,
-    CONF_STEP,
     DEFAULT_TEMP_UNIT,
     DEFAULT_UNITS,
     CONF_HUB_NAME,
@@ -29,11 +26,6 @@ from ..const import (
 )
 # Opzioni runtime
 OPT_UPDATE_INTERVAL_S = "update_interval_s"
-OPT_SUPPORTS_HEATING = "supports_heating"
-OPT_SUPPORTS_COOLING = "supports_cooling"
-OPT_SUPPORTS_DEHUMIDIFYING = "supports_dehumidifying"
-OPT_SETPOINT_STEP_C = "setpoint_step_c"
-OPT_MANUAL_OVERRIDE_MIN = "manual_override_minutes"
 
 def schema_user() -> vol.Schema:
     """Form iniziale (user)."""
@@ -69,14 +61,6 @@ def schema_dynamic(cur: Mapping[str, Any], entry_data: Mapping[str, Any]) -> vol
     return vol.Schema(
         {
             vol.Required(OPT_UPDATE_INTERVAL_S, default=cur.get(OPT_UPDATE_INTERVAL_S, 30)): vol.All(int, vol.Range(min=5, max=3600)),
-            vol.Required(OPT_SUPPORTS_HEATING, default=cur.get(OPT_SUPPORTS_HEATING, True)): bool,
-            vol.Required(OPT_SUPPORTS_COOLING, default=cur.get(OPT_SUPPORTS_COOLING, False)): bool,
-            vol.Required(OPT_SUPPORTS_DEHUMIDIFYING, default=cur.get(OPT_SUPPORTS_DEHUMIDIFYING, False)): bool,
-            vol.Required(OPT_SETPOINT_STEP_C, default=cur.get(OPT_SETPOINT_STEP_C, 0.5)): vol.All(vol.Coerce(float), vol.Range(min=0.1, max=2.0)),
-            vol.Required(OPT_MANUAL_OVERRIDE_MIN, default=cur.get(OPT_MANUAL_OVERRIDE_MIN, 90)): vol.All(int, vol.Range(min=5, max=720)),
-            vol.Required(CONF_MAX_TEMP, default=cur.get(CONF_MAX_TEMP, 35.0)): vol.Coerce(float),
-            vol.Required(CONF_MIN_TEMP, default=cur.get(CONF_MIN_TEMP, 5.0)): vol.Coerce(float),
-            vol.Required(CONF_STEP, default=cur.get(CONF_STEP, 0.5)): vol.All(vol.Coerce(float), vol.Range(min=0.1, max=2.0)),
             vol.Required(CONF_UNITS, default=units_default): units_selector,
             vol.Required(CONF_TEMPERATURE_UNIT, default=temp_unit_default): temp_unit_selector,
         }


### PR DESCRIPTION
## Summary
- drop unused capability flags and temperature bounds from the config flow defaults and option forms
- simplify the dynamic step schema so it only asks for update interval and units
- stop populating deprecated temperature and capability fields when importing YAML configurations

## Testing
- python -m compileall custom_components/drp_climate_master_v2

------
https://chatgpt.com/codex/tasks/task_e_68fa4acbe7488332bbc8233d438e57de